### PR TITLE
harden: executing non-constant commands in Helper.php...

### DIFF
--- a/lib/Controller/Helper.php
+++ b/lib/Controller/Helper.php
@@ -253,16 +253,12 @@ class Helper
 
       $file = $wtlog;
       $fragment = '';
-      if ($this->isExecAvailable()) {
-          $fragment = exec("sed -n '{$zeile}p' " . escapeshellarg($file));
-      } else {
-          try {
-              $fileObj = new \SplFileObject($file);
-              $fileObj->seek($zeile - 1);
-              $fragment = $fileObj->current();
-          } catch (\Exception $e) {
-              $fragment = 'could not read line';
-          }
+      try {
+          $fileObj = new \SplFileObject($file);
+          $fileObj->seek($zeile - 1);
+          $fragment = $fileObj->current();
+      } catch (\Exception $e) {
+          $fragment = 'could not read line';
       }
 
       $fragment = str_replace(['{', '}'], '', (string)$fragment);
@@ -287,40 +283,23 @@ class Helper
           'version' => $version
       ]);
 
-      if ($this->isExecAvailable()) {
-          $tmpNew = tempnam(sys_get_temp_dir(), 'newline_');
-          file_put_contents($tmpNew, $replaceWith . PHP_EOL);
+      $tempFile = $file . '.tmp';
+      $handleIn = fopen($file, 'r');
+      $handleOut = fopen($tempFile, 'w');
 
-          $cmd = sprintf(
-              "awk -v n=%d -v f=%s 'NR==n{while((getline line < f)>0){print line}; close(f); next} {print}' %s > %s && mv %s %s",
-              $zeile,
-              escapeshellarg($tmpNew),
-              escapeshellarg($file),
-              escapeshellarg($file . '.tmp'),
-              escapeshellarg($file . '.tmp'),
-              escapeshellarg($file)
-          );
-          exec($cmd . ' 2>&1');
-          @unlink($tmpNew);
-      } else {
-          $tempFile = $file . '.tmp';
-          $handleIn = fopen($file, 'r');
-          $handleOut = fopen($tempFile, 'w');
-
-          if ($handleIn && $handleOut) {
-              $currentLine = 0;
-              while (($line = fgets($handleIn)) !== false) {
-                  $currentLine++;
-                  if ($currentLine === $zeile) {
-                      fwrite($handleOut, $replaceWith . PHP_EOL);
-                  } else {
-                      fwrite($handleOut, $line);
-                  }
+      if ($handleIn && $handleOut) {
+          $currentLine = 0;
+          while (($line = fgets($handleIn)) !== false) {
+              $currentLine++;
+              if ($currentLine === $zeile) {
+                  fwrite($handleOut, $replaceWith . PHP_EOL);
+              } else {
+                  fwrite($handleOut, $line);
               }
-              fclose($handleIn);
-              fclose($handleOut);
-              rename($tempFile, $file);
           }
+          fclose($handleIn);
+          fclose($handleOut);
+          rename($tempFile, $file);
       }
 
       return [


### PR DESCRIPTION
## Summary
Harden input handling in `lib/Controller/Helper.php` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | php.lang.security.exec-use.exec-use |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `php.lang.security.exec-use.exec-use` |
| **File** | `lib/Controller/Helper.php:257` |
| **Assessment** | Defensive hardening |

**Description**: Executing non-constant commands. This can lead to command injection.

## Changes
- `lib/Controller/Helper.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
